### PR TITLE
Fix the recentEpisodes tables missing indexes due to CREATE TABLE AS

### DIFF
--- a/migrations/0023_recentEpisodes.sql
+++ b/migrations/0023_recentEpisodes.sql
@@ -1,0 +1,22 @@
+-- Adding the table creations here in case someone doesn't have them.
+-- NOTE: The indexes inevitably get renamed due to CREATE TABLE LIKE process.
+
+CREATE TABLE IF NOT EXISTS "recentEpisodesByPodcast" (
+  "episodeId" character varying(14) NOT NULL,
+  "podcastId" character varying(14) NOT NULL,
+  "pubDate" timestamp without time zone
+);
+
+ALTER TABLE "recentEpisodesByPodcast" ADD CONSTRAINT "PK_recentEpisodesByPodcast" PRIMARY KEY ("episodeId");
+
+CREATE INDEX "recentEpisodesByPodcast_podcastId_pubDate_idx" ON "recentEpisodesByPodcast" ("podcastId", "pubDate" DESC);
+
+CREATE TABLE IF NOT EXISTS "recentEpisodesByCategory" (
+  "episodeId" character varying(14) NOT NULL,
+  "categoryId" character varying(14) NOT NULL,
+  "pubDate" timestamp without time zone
+);
+
+ALTER TABLE "recentEpisodesByCategory" ADD CONSTRAINT "PK_recentEpisodesByCategory" PRIMARY KEY ("episodeId");
+
+CREATE INDEX "recentEpisodesByCategory_categoryId_pubDate_idx" ON "recentEpisodesByCategory" ("categoryId", "pubDate" DESC);

--- a/src/entities/recentEpisodeByCategory.ts
+++ b/src/entities/recentEpisodeByCategory.ts
@@ -1,15 +1,14 @@
 import { Column, Entity, Index, PrimaryColumn } from 'typeorm'
 
 @Entity('recentEpisodesByCategory')
-@Index(['categoryId', 'episodeId'], { unique: true })
+@Index(['categoryId', 'pubDate'])
 export class RecentEpisodeByCategory {
-  @PrimaryColumn()
-  categoryId: string
-
   @PrimaryColumn()
   episodeId: string
 
-  @Index()
+  @Column()
+  categoryId: string
+
   @Column({ nullable: true })
   pubDate?: Date
 }

--- a/src/entities/recentEpisodeByPodcast.ts
+++ b/src/entities/recentEpisodeByPodcast.ts
@@ -1,15 +1,14 @@
 import { Column, Entity, Index, PrimaryColumn  } from 'typeorm'
 
 @Entity('recentEpisodesByPodcast')
-@Index(['podcastId', 'episodeId'], { unique: true })
+@Index(['podcastId', 'pubDate'])
 export class RecentEpisodeByPodcast {
   @PrimaryColumn()
+  episodeId: string
+  
+  @Column()
   podcastId: string
 
-  @PrimaryColumn()
-  episodeId: string
-
-  @Index()
   @Column({ nullable: true })
   pubDate?: Date
 }


### PR DESCRIPTION
CREATE TABLE AS ( SELECT STATEMENT ...) does not include any well-defined schema (compared to using LIKE) so whenever the Combined tables are populated and renamed, they no longer retain the indexes on the original tables (thus in production there are no indexes right now). I created a migrations file to add the missing indexes, then converted the CREATE TABLE AS queries into separate CREATE TABLE LIKE and INSERT INTO ... SELECT statements in order to preserve the indexes.